### PR TITLE
Fix ASE problem with logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,10 +121,10 @@ lint.select = [
 ]
 lint.ignore = [
   "E501",   # Line too long
+  "A005",  # Unused built-in
   "ISC001",   # single-line-implicit-string-concatenation
   "PERF203",  # try-except-in-loop
   "PLR",    # Design related pylint codes
-  "PT004",  # Fixture does not return anything
   "PT011",  # pytest.raises
   "PT012",  # pytest.raises
   "RET505", # Unnecessary `elif` after `return`

--- a/src/quansino/mc/core.py
+++ b/src/quansino/mc/core.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from typing import Any
 
     from ase.atoms import Atoms
-    from ase.outputs import Properties
 
 
 class AcceptanceCriteria[ContextType: Context](ABC):
@@ -197,7 +196,7 @@ class MonteCarlo[MoveType: BaseMove, ContextType: Context](Dynamics):
             is_converged = self.converged()
             yield is_converged
 
-    def step(self, properties: Properties | None = None) -> Any: ...  # type: ignore
+    def step(self) -> Any: ...  # type: ignore
 
     def run(self, steps=100_000_000) -> bool:  # type: ignore
         """

--- a/src/quansino/mc/core.py
+++ b/src/quansino/mc/core.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     from ase.atoms import Atoms
+    from ase.outputs import Properties
 
 
 class AcceptanceCriteria[ContextType: Context](ABC):
@@ -164,7 +165,7 @@ class MonteCarlo[MoveType: BaseMove, ContextType: Context](Dynamics):
             criteria=criteria,
         )
 
-    def irun(self, *args, **kwargs) -> Generator[bool, None, None]:  # type: ignore
+    def irun(self, steps=100_000_000) -> Generator[bool, None, None]:  # type: ignore
         """
         Run the Monte Carlo simulation for a given number of steps.
 
@@ -178,9 +179,27 @@ class MonteCarlo[MoveType: BaseMove, ContextType: Context](Dynamics):
 
         self.validate_simulation()
 
-        return super().irun(*args, **kwargs)
+        self.max_steps = self.nsteps + steps
 
-    def run(self, *args, **kwargs) -> bool:  # type: ignore
+        self.atoms.get_potential_energy()
+        self.call_observers()
+
+        is_converged = self.converged()
+        yield is_converged
+
+        while not is_converged and self.nsteps < self.max_steps:
+            self.step()
+            self.nsteps += 1
+
+            self.atoms.get_potential_energy()
+            self.call_observers()
+
+            is_converged = self.converged()
+            yield is_converged
+
+    def step(self, properties: Properties | None = None) -> Any: ...  # type: ignore
+
+    def run(self, steps=100_000_000) -> bool:  # type: ignore
         """
         Run the Monte Carlo simulation for a given number of steps.
 
@@ -189,12 +208,7 @@ class MonteCarlo[MoveType: BaseMove, ContextType: Context](Dynamics):
         bool
             True if the simulation is converged.
         """
-        if self.default_logger:
-            self.default_logger.write_header()
-
-        self.validate_simulation()
-
-        return super().run(*args, **kwargs)
+        return list(self.irun(steps=steps))[-1]
 
     def create_context(self, atoms: Atoms, rng: RNG) -> ContextType: ...
 

--- a/tests/mc/test_canonical.py
+++ b/tests/mc/test_canonical.py
@@ -99,7 +99,7 @@ def test_canonical(bulk_small, tmp_path):
 
     acceptance_from_log = np.loadtxt(tmp_path / "mc.log", skiprows=13, usecols=-1)
 
-    assert_array_equal(acceptances[1:], acceptance_from_log)
+    assert_array_equal(acceptances, acceptance_from_log)
     assert_allclose(np.sum(acceptances), 500, atol=100)
 
     move_storage = MoveStorage[DisplacementMove, DisplacementContext](


### PR DESCRIPTION
ASE currently relies on the `Dynamics.log` method to perform calculation if the `step` method modified the atoms.